### PR TITLE
feat: add group and grouping global default settings

### DIFF
--- a/lang/en/local_mass_enroll.php
+++ b/lang/en/local_mass_enroll.php
@@ -283,3 +283,9 @@ Please note "manual" cannot be configured as this is the default and will always
 $string['enableextraunenrolmentplugins'] = 'Allow extra unenrolment plugins?';
 $string['enableextraunenrolmentplugins_help'] = 'Use this if you wish to allow for unenrolment of other plugins than "manual"';
 $string['privacy:metadata'] = 'The Mass Enrol local plugin does not store any personal data';
+
+$string['defaultvalues'] = 'Default form values';
+$string['defaultcreategroups'] = 'Default create group value';
+$string['defaultcreategroups_help'] = 'This value will be used as the default value of the "Create group(s) if needed" checkbox when mass-enrolling';
+$string['defaultcreategroupings'] = 'Default create groupings value';
+$string['defaultcreategroupings_help'] = 'This value will be used as the default value of the "Create groupings(s) if needed" checkbox when mass-enrolling';

--- a/mass_enroll_form.php
+++ b/mass_enroll_form.php
@@ -87,14 +87,16 @@ class mass_enroll_form extends moodleform {
         $mform->setDefault('firstcolumn', 'idnumber');
 
         $mform->addElement('selectyesno', 'creategroups', get_string('creategroups', 'local_mass_enroll'));
-        $mform->setDefault('creategroups', 1);
+        $defaultcreategroups = get_config('local_mass_enroll', 'defaultcreategroups') ?: 0;
+        $mform->setDefault('creategroups', $defaultcreategroups);
 
         $mform->addElement('selectyesno', 'purgegroupsbeforecreating',
             get_string('purgegroupsbeforecreating', 'local_mass_enroll'));
         $mform->setDefault('purgegroupsbeforecreating', 0);
 
         $mform->addElement('selectyesno', 'creategroupings', get_string('creategroupings', 'local_mass_enroll'));
-        $mform->setDefault('creategroupings', 1);
+        $defaultcreategroupings = get_config('local_mass_enroll', 'defaultcreategroupings') ?: 0;
+        $mform->setDefault('creategroupings', $defaultcreategroupings);
 
         $mform->addElement('selectyesno', 'mailreport', get_string('mailreport', 'local_mass_enroll'));
         $mform->setDefault('mailreport', (int)$config->mailreportdefault);

--- a/settings.php
+++ b/settings.php
@@ -64,6 +64,19 @@ if ($hassiteconfig) {
     $settings->add(new admin_setting_configcheckbox('local_mass_enroll/enablemassunenrol',
         get_string('enablemassunenrol', 'local_mass_enroll'),
         get_string('enablemassunenrol_help', 'local_mass_enroll'), 1));
+    
+    // Default values section.
+    $settings->add(new admin_setting_heading('local_mass_enroll/defaultvalues',
+        get_string('defaultvalues', 'local_mass_enroll'),
+        ''));
+
+    $settings->add(new admin_setting_configcheckbox('local_mass_enroll/defaultcreategroups',
+        get_string('defaultcreategroups', 'local_mass_enroll'),
+        get_string('defaultcreategroups_help', 'local_mass_enroll'), 0));
+
+    $settings->add(new admin_setting_configcheckbox('local_mass_enroll/defaultcreategroupings',
+        get_string('defaultcreategroupings', 'local_mass_enroll'),
+        get_string('defaultcreategroupings_help', 'local_mass_enroll'), 0));
 
     $ADMIN->add('localplugins', $settings);
 }

--- a/version.php
+++ b/version.php
@@ -28,7 +28,7 @@
  * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 defined('MOODLE_INTERNAL') || die();
-$plugin->version   = 2018082402;            // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2018082403;            // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2018050200;            // Moodle 3.5 onwards.
 $plugin->component = 'local_mass_enroll';   // Full name of the plugin (used for diagnostics).
 $plugin->maturity  = MATURITY_STABLE;       // Required for registering to Moodle's database of plugins.


### PR DESCRIPTION
Added two new settings that set the default values of the create group & groupings checkboxes when mass enrolling.

IMO nearly all the time we want these default to false, so the user doesn't accidentally create groups. But for flexibility, I added them as a global plugin setting so the admin can default on/off as needed.

