### PR TITLE
checknonmanualenrolments: Check for all enrolment types to avoid dupes

### DIFF
--- a/lang/en/local_mass_enroll.php
+++ b/lang/en/local_mass_enroll.php
@@ -284,6 +284,9 @@ $string['enableextraunenrolmentplugins'] = 'Allow extra unenrolment plugins?';
 $string['enableextraunenrolmentplugins_help'] = 'Use this if you wish to allow for unenrolment of other plugins than "manual"';
 $string['privacy:metadata'] = 'The Mass Enrol local plugin does not store any personal data';
 
+$string['checknonmanualenrolments'] = 'Check enrolments from all plugins when enroling';
+$string['checknonmanualenrolments_help'] = 'Use this if you wish to look at all plugins rather than just "manual" when checking users for existing enrolments.';
+
 $string['defaultvalues'] = 'Default form values';
 $string['defaultcreategroups'] = 'Default create group value';
 $string['defaultcreategroups_help'] = 'This value will be used as the default value of the "Create group(s) if needed" checkbox when mass-enrolling';

--- a/lib.php
+++ b/lib.php
@@ -101,6 +101,8 @@ function mass_enroll($cir, $course, $context, $data) {
     $createdgroups = '';
     $createdgroupings = '';
 
+    $checknonmanualenrolments = get_config('local_mass_enroll', 'checknonmanualenrolments');
+
     $role = $DB->get_record('role', array('id' => $roleid));
 
     $result .= get_string('im:using_role', 'local_mass_enroll', $role->name) . "\n";
@@ -146,7 +148,9 @@ function mass_enroll($cir, $course, $context, $data) {
         foreach ($users as $user) {
             // Already enroled?
             // We DO NOT support multiple roles in a course.
-            if ($ue = $DB->get_record('user_enrolments', array('enrolid' => $instance->id, 'userid' => $user->id))) {
+            if ($checknonmanualenrolments && user_has_role_assignment($user->id, $roleid, $context->id)) {
+                $result .= get_string('im:already_in', 'local_mass_enroll', fullname($user));
+            } else if ($DB->record_exists('user_enrolments', array('enrolid' => $instance->id, 'userid' => $user->id))) {
                 $result .= get_string('im:already_in', 'local_mass_enroll', fullname($user));
             } else {
                 // Take care of timestart/timeend in course settings.

--- a/settings.php
+++ b/settings.php
@@ -44,6 +44,10 @@ if ($hassiteconfig) {
         get_string('mailreportdefault', 'local_mass_enroll'),
         get_string('mailreportdefault_help', 'local_mass_enroll'), 1, $yesno));
 
+    $settings->add(new admin_setting_configcheckbox('local_mass_enroll/checknonmanualenrolments',
+        get_string('checknonmanualenrolments', 'local_mass_enroll'),
+        get_string('checknonmanualenrolments_help', 'local_mass_enroll'), 0));
+
     $settings->add(new admin_setting_configcheckbox('local_mass_enroll/enableextraunenrolmentplugins',
         get_string('enableextraunenrolmentplugins', 'local_mass_enroll'),
         get_string('enableextraunenrolmentplugins_help', 'local_mass_enroll'), 0));

--- a/tests/checknonmanualenrolments_test.php
+++ b/tests/checknonmanualenrolments_test.php
@@ -14,17 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * Upgrade code for local_mass_enroll
- *
- * @package     local_mass_enroll
- * @author Andrew Hancox <andrewdchancox@googlemail.com>
- * @author Open Source Learning <enquiries@opensourcelearning.co.uk>
- * @link https://opensourcelearning.co.uk
- * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- * @copyright 2023, Andrew Hancox
- */
-
 namespace local_mass_enroll;
 
 use advanced_testcase;
@@ -32,7 +21,7 @@ use context_course;
 use csv_import_reader;
 
 /**
- * Mass enrol unit tests
+ * Mass enrol unit tests checking checknonmanualenrolments option is respected
  *
  * @package   local_mass_enroll
  * @copyright 2023, Andrew Hancox
@@ -114,6 +103,7 @@ class checknonmanualenrolments_test extends advanced_testcase {
             $this->assertCount(1, $DB->get_records('user_enrolments', ['userid' => $users[$i]->id, 'enrolid' => $courseenrol->id]));
         }
 
+        // 2. This user should have one or two enrolments based on the parameters the test runs with
         $this->assertCount($checknonmanualenrolments ? 1 : 2, $DB->get_records('user_enrolments', ['userid' => $alreadyenrolleduser->id]));
     }
 }

--- a/tests/checknonmanualenrolments_test.php
+++ b/tests/checknonmanualenrolments_test.php
@@ -1,0 +1,119 @@
+<?php
+// This file is part of the Arup cost centre system
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Upgrade code for local_mass_enroll
+ *
+ * @package     local_mass_enroll
+ * @author Andrew Hancox <andrewdchancox@googlemail.com>
+ * @author Open Source Learning <enquiries@opensourcelearning.co.uk>
+ * @link https://opensourcelearning.co.uk
+ * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @copyright 2023, Andrew Hancox
+ */
+
+namespace local_mass_enroll;
+
+use advanced_testcase;
+use context_course;
+use csv_import_reader;
+
+/**
+ * Mass enrol unit tests
+ *
+ * @package   local_mass_enroll
+ * @copyright 2023, Andrew Hancox
+ * @author Andrew Hancox <andrewdchancox@googlemail.com>
+ * @author Open Source Learning <enquiries@opensourcelearning.co.uk>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class checknonmanualenrolments_test extends advanced_testcase {
+
+    /**
+     * Provides to test_mass_enroll
+     */
+    public function checknonmanualenrolments_provider(): array {
+        return [
+            'true' => [
+                'checknonmanualenrolments' => true,
+            ],
+            'false' => [
+                'checknonmanualenrolments' => false,
+            ]
+        ];
+    }
+
+    /**
+     * Tests mass_enroll function
+     * @param bool $checknonmanualenrolments checknonmanualenrolments config setting
+     * @dataProvider checknonmanualenrolments_provider
+     * @covers       \local_mass_enroll\mass_enroll
+     */
+    public function test_checknonmanualenrolments($checknonmanualenrolments) {
+        global $DB, $CFG;
+        require_once(__DIR__ . '/../lib.php');
+        require_once($CFG->libdir . '/csvlib.class.php');
+
+        $this->resetAfterTest();
+
+        set_config('checknonmanualenrolments', $checknonmanualenrolments, 'local_mass_enroll');
+
+        $selfplugin = enrol_get_plugin('self');
+        $studentrole = $DB->get_record('role', array('shortname' => 'student'));
+        $alreadyenrolleduser = $this->getDataGenerator()->create_user(['idnumber' => 'alreadyenrolleduser']);
+
+        $course = $this->getDataGenerator()->create_course();
+        $instance1 = $DB->get_record('enrol', array('courseid' => $course->id, 'enrol' => 'self'), '*', MUST_EXIST);
+        $selfplugin->enrol_user($instance1, $alreadyenrolleduser->id, $studentrole->id);
+
+        $users = [];
+
+        for ($i = 1; $i < 4; $i++) {
+            $users[$i] = $this->getDataGenerator()->create_user(['idnumber' => $i]);
+        }
+
+        // Import test data.
+        $content = file_get_contents(__DIR__ . '/fixtures/checknonmanualenrolments.csv');
+        $iid = csv_import_reader::get_new_iid('uploaduser');
+        $cir = new csv_import_reader($iid, 'uploaduser');
+        $cir->load_csv_content($content, 'UTF-8', 'comma');
+
+        // Fake the moodle form data.
+        $studentrole = $DB->get_record('role', ['shortname' => 'student']);
+        $mformdata = (object)[
+            'roleassign' => $studentrole->id,
+            'firstcolumn' => 'idnumber',
+            'creategroups' => true,
+            'creategroupings' => true,
+            'mailreport' => false,
+            'purgegroupsbeforecreating' => false
+        ];
+
+        // Run the import.
+        $output = mass_enroll($cir, $course, context_course::instance($course->id), $mformdata);
+
+        // Test the data was corrected created.
+
+        // 1. All users should have exactly 1 enrolment into the course (i.e. no duplicates)
+        $courseenrol = current(enrol_get_instances($course->id, true));
+
+        for ($i = 1; $i < 4; $i++) {
+            $this->assertCount(1, $DB->get_records('user_enrolments', ['userid' => $users[$i]->id, 'enrolid' => $courseenrol->id]));
+        }
+
+        $this->assertCount($checknonmanualenrolments ? 1 : 2, $DB->get_records('user_enrolments', ['userid' => $alreadyenrolleduser->id]));
+    }
+}

--- a/tests/fixtures/checknonmanualenrolments.csv
+++ b/tests/fixtures/checknonmanualenrolments.csv
@@ -1,0 +1,5 @@
+idnumber,group1,group2
+1,group1,groupa
+2,group1,groupa
+3,group1,groupa
+alreadyenrolleduser,group1,groupa


### PR DESCRIPTION
To avoid duplicating enrolments from other plugins optionally check role assignments.